### PR TITLE
Handle MPD manifests and validate download URLs

### DIFF
--- a/cda_dl/download_state.py
+++ b/cda_dl/download_state.py
@@ -3,3 +3,4 @@ class DownloadState:
         self.completed = 0
         self.skipped = 0
         self.failed = 0
+        self.errors: list[str] = []

--- a/cda_dl/downloader.py
+++ b/cda_dl/downloader.py
@@ -92,6 +92,10 @@ class Downloader:
                     " - [red bold]Nieudane Pliki:"
                     f" {self.download_state.failed}[/] |\n"
                 )
+                if self.download_state.errors:
+                    console.print("[red bold]Szczegóły błędów:[/]")
+                    for error in self.download_state.errors:
+                        console.print(f"- {error}")
                 console.print("Skończono pobieranie. Enjoy :)")
 
     async def perform_login(self, session: aiohttp.ClientSession) -> None:

--- a/cda_dl/video.py
+++ b/cda_dl/video.py
@@ -5,6 +5,9 @@ import re
 from pathlib import Path
 from typing import Any
 
+import shutil
+from urllib.parse import urljoin
+
 import aiofiles
 import aiohttp
 from bs4 import BeautifulSoup
@@ -51,6 +54,9 @@ class Video:
     filepath: Path
     partial_filepath: Path
     resume_point: int
+    is_dash: bool
+    dash_video_url: str
+    dash_audio_url: str
 
     def __init__(
         self, url: str, session: aiohttp.ClientSession, ui: RichUI
@@ -62,6 +68,149 @@ class Video:
             "Content-Type": "application/json",
             "X-Requested-With": "XMLHttpRequest",
         }
+        self.is_dash = False
+        self.dash_video_url = ""
+        self.dash_audio_url = ""
+
+    def is_mpd_url(self, url: str) -> bool:
+        return url.lower().endswith(".mpd")
+
+    async def initialize_dash(self) -> None:
+        response = await get_request(self.file, self.session, {})
+        mpd_text = await response.text()
+        self.dash_video_url, self.dash_audio_url = self.parse_mpd(
+            mpd_text, self.file
+        )
+
+    def parse_mpd(self, mpd_text: str, mpd_url: str) -> tuple[str, str]:
+        soup = BeautifulSoup(mpd_text, "xml")
+
+        video_url = None
+        audio_url = None
+
+        for adaptation_set in soup.find_all("AdaptationSet"):
+            content_type = adaptation_set.get("contentType")
+
+            if content_type == "video":
+                matched_representation = None
+
+                for representation in adaptation_set.find_all("Representation"):
+                    height = representation.get("height")
+                    if height and self.resolution == f"{height}p":
+                        matched_representation = representation
+                        break
+
+                if matched_representation is None:
+                    representations = adaptation_set.find_all("Representation")
+                    if not representations:
+                        continue
+                    matched_representation = max(
+                        representations,
+                        key=lambda rep: int(rep.get("height", "0")),
+                    )
+
+                base_url = matched_representation.find("BaseURL")
+                if base_url and base_url.text:
+                    video_url = urljoin(mpd_url, base_url.text.strip())
+
+            elif content_type == "audio":
+                representation = adaptation_set.find("Representation")
+                if representation:
+                    base_url = representation.find("BaseURL")
+                    if base_url and base_url.text:
+                        audio_url = urljoin(mpd_url, base_url.text.strip())
+
+        if not video_url:
+            raise ParserError(
+                f"Nie udało się znaleźć strumienia video w MPD dla {self.url}"
+            )
+
+        if not audio_url:
+            raise ParserError(
+                f"Nie udało się znaleźć strumienia audio w MPD dla {self.url}"
+            )
+
+        return video_url, audio_url
+
+    def get_dash_video_filepath(self) -> Path:
+        return self.filepath.parent / f"{self.filepath.stem}.video.mp4"
+
+    def get_dash_audio_filepath(self) -> Path:
+        return self.filepath.parent / f"{self.filepath.stem}.audio.mp4"
+
+    async def download_url_to_file(
+        self, url: str, path: Path, desc: str
+    ) -> None:
+        response = await get_request(url, self.session, {})
+        total = int(response.headers.get("content-length", 0))
+
+        assert self.ui.progbar_video
+        task_id = self.ui.progbar_video.add_task(
+            "download",
+            filename=desc,
+            total=total if total > 0 else None,
+        )
+
+        async with aiofiles.open(path, "wb") as f:
+            async for chunk in response.content.iter_chunked(1024 * 1024):
+                await f.write(chunk)
+                self.ui.progbar_video.update(task_id, advance=len(chunk))
+
+        self.ui.progbar_video.remove_task(task_id)
+
+    async def merge_dash_streams(
+        self, video_path: Path, audio_path: Path, output_path: Path
+    ) -> None:
+        if shutil.which("ffmpeg") is None:
+            raise ParserError(
+                "Wykryto materiał MPEG-DASH, ale ffmpeg nie jest zainstalowany."
+            )
+
+        process = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
+            "-i",
+            str(audio_path),
+            "-c",
+            "copy",
+            str(output_path),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        return_code = await process.wait()
+
+        if return_code != 0:
+            raise ParserError(
+                f"ffmpeg nie zdołał scalić audio i video dla {self.url}"
+            )
+
+    async def download_dash(self, download_state: DownloadState) -> None:
+        video_tmp = self.get_dash_video_filepath()
+        audio_tmp = self.get_dash_audio_filepath()
+
+        self.filepath.unlink(missing_ok=True)
+        video_tmp.unlink(missing_ok=True)
+        audio_tmp.unlink(missing_ok=True)
+
+        try:
+            await self.download_url_to_file(
+                self.dash_video_url,
+                video_tmp,
+                f"{self.title}.video.mp4 [{self.resolution}]",
+            )
+            await self.download_url_to_file(
+                self.dash_audio_url,
+                audio_tmp,
+                f"{self.title}.audio.mp4 [{self.resolution}]",
+            )
+            await self.merge_dash_streams(video_tmp, audio_tmp, self.filepath)
+        finally:
+            video_tmp.unlink(missing_ok=True)
+            audio_tmp.unlink(missing_ok=True)
+
+        download_state.completed += 1
 
     async def download_video(
         self, download_options: DownloadOptions, download_state: DownloadState
@@ -94,7 +243,10 @@ class Video:
                 download_state.failed += 1
         else:
             self.make_directory(download_options)
-            await self.stream_file(download_state)
+            if self.is_dash:
+                await self.download_dash(download_state)
+            else:
+                await self.stream_file(download_state)
 
     async def pre_initialize(self, download_options: DownloadOptions) -> None:
         """Initialize members required to get Video info."""
@@ -131,10 +283,24 @@ class Video:
             self.headers,
         )
         data = await resp.json()
-        self.file = data["result"]["resp"]
+        file_resp = data.get("result", {}).get("resp")
+
+        if not isinstance(file_resp, str) or not file_resp.startswith(("http://", "https://")):
+            raise ParserError(
+                f"CDA nie zwróciło poprawnego linku do pliku dla {self.url}. "
+                f"Odpowiedź API: {file_resp!r}"
+            )
+
+        self.file = file_resp
         self.resume_point = self.get_resume_point()
-        self.video_stream = await self.get_video_stream()
-        self.remaining_size = self.get_remaining_size()
+
+        if self.is_mpd_url(self.file):
+            self.is_dash = True
+            await self.initialize_dash()
+        else:
+            self.video_stream = await self.get_video_stream()
+            self.remaining_size = self.get_remaining_size()
+
 
     def get_videoid(self) -> str:
         """Get videoid from Video url."""
@@ -265,9 +431,11 @@ class Video:
         )
 
     async def get_video_stream(self) -> aiohttp.ClientResponse:
-        range_num = f"bytes={self.resume_point}-"
-        self.headers["Range"] = range_num
-        video_stream = await get_request(self.file, self.session, self.headers)
+        if not isinstance(self.file, str) or not self.file.startswith(("http://", "https://")):
+            raise ParserError(f"Nieprawidłowy URL strumienia: {self.file!r}")
+
+        headers = {"Range": f"bytes={self.resume_point}-"}
+        video_stream = await get_request(self.file, self.session, headers)
         return video_stream
 
     def get_remaining_size(self) -> int:

--- a/cda_dl/video.py
+++ b/cda_dl/video.py
@@ -254,13 +254,17 @@ class Video:
             ResolutionError,
             ParserError,
             HTTPError,
+            asyncio.TimeoutError,
+            aiohttp.ClientError,
         ) as e:
             if isinstance(e, HTTPError) and e.status_code == 429:
                 LOGGER.warning("Zbyt dużo zapytań. Usypiam wątek na 10 min.")
                 await asyncio.sleep(60 * 10)
                 await self.download_video(download_options, download_state)
             else:
-                LOGGER.warning(e)
+                message = f"[{self.url}] {type(e).__name__}: {e}"
+                LOGGER.warning(message)
+                download_state.errors.append(message)
                 download_state.failed += 1
         else:
             self.make_directory(download_options)
@@ -332,17 +336,70 @@ class Video:
     async def get_video_soup(self) -> BeautifulSoup:
         response = await get_request(self.url, self.session, self.headers)
         text = await response.text()
+
+        if self.requires_adult_confirmation(text) and not self.has_media_player(text):
+            LOGGER.warning(
+                f"Wykryto bramkę 18+ dla {self.url}, wysyłam potwierdzenie wieku"
+            )
+
+            self.session.cookie_jar.update_cookies(
+                {"adult": "1"},
+                response.url,
+            )
+
+            post_response = await self.session.post(
+                self.url,
+                data={"age_confirm": "1"},
+                headers={"User-Agent": self.headers.get("User-Agent", "")},
+            )
+            post_response.raise_for_status()
+            text = await post_response.text()
+
+            if not self.has_media_player(text):
+                response = await get_request(self.url, self.session, self.headers)
+                text = await response.text()
+
+            if not self.has_media_player(text):
+                raise ParserError(
+                    f"Nie udało się przejść bramki 18+ dla {self.url} - nadal brak media playera."
+                )
+
         return BeautifulSoup(text, "html.parser")
+
+    def has_media_player(self, html: str) -> bool:
+        video_id = self.get_videoid()
+        return f'id="mediaplayer{video_id}"' in html
+
+    def requires_adult_confirmation(self, html: str) -> bool:
+        return (
+            'class="boxAdult"' in html
+            or 'name="age_confirm"' in html
+            or "Materiał przeznaczony dla osób pełnoletnich" in html
+        )
 
     def get_video_title(self) -> str:
         title_tag = self.video_soup.find("h1")
-        if not isinstance(title_tag, Tag):
-            raise ParserError(
-                "Error podczas parsowania 'video title' dla"
-                f" {self.url} Pomijam ..."
-            )
-        title = title_tag.text.strip("\n")
-        return get_safe_title(title)
+        if isinstance(title_tag, Tag):
+            title = title_tag.get_text(strip=True)
+            if title:
+                return get_safe_title(title)
+
+        meta_og = self.video_soup.find("meta", attrs={"property": "og:title"})
+        if isinstance(meta_og, Tag):
+            content = meta_og.get("content")
+            if isinstance(content, str) and content.strip():
+                return get_safe_title(content.strip())
+
+        page_title = self.video_soup.find("title")
+        if isinstance(page_title, Tag):
+            title = page_title.get_text(strip=True)
+            if title:
+                return get_safe_title(title)
+
+        raise ParserError(
+            f"Error podczas parsowania 'video title' dla {self.url}. "
+            "Brak <h1>, og:title i <title>. Pomijam ..."
+        )
 
     def get_filepath(self, download_options: DownloadOptions) -> Path:
         return Path(download_options.directory, f"{self.title}.mp4")

--- a/cda_dl/video.py
+++ b/cda_dl/video.py
@@ -133,30 +133,52 @@ class Video:
         return video_url, audio_url
 
     def get_dash_video_filepath(self) -> Path:
-        return self.filepath.parent / f"{self.filepath.stem}.video.mp4"
+        return self.filepath.parent / f"{self.filepath.stem}.video.mp4.part"
 
     def get_dash_audio_filepath(self) -> Path:
-        return self.filepath.parent / f"{self.filepath.stem}.audio.mp4"
+        return self.filepath.parent / f"{self.filepath.stem}.audio.mp4.part"
 
     async def download_url_to_file(
         self, url: str, path: Path, desc: str
     ) -> None:
-        response = await get_request(url, self.session, {})
-        total = int(response.headers.get("content-length", 0))
+        resume_point = path.stat().st_size if path.exists() else 0
+        headers: dict[str, str] = {}
+
+        if resume_point > 0:
+            headers["Range"] = f"bytes={resume_point}-"
+
+        response = await get_request(url, self.session, headers)
+
+        if resume_point > 0 and response.status != 206:
+            LOGGER.warning(
+                f"Serwer nie wznowił pobierania dla '{desc}', zaczynam od zera."
+            )
+            resume_point = 0
+            path.unlink(missing_ok=True)
+            response = await get_request(url, self.session, {})
+
+        content_length = int(response.headers.get("content-length", 0))
+        total = resume_point + content_length if content_length > 0 else None
 
         assert self.ui.progbar_video
         task_id = self.ui.progbar_video.add_task(
             "download",
             filename=desc,
-            total=total if total > 0 else None,
+            total=total,
+            completed=resume_point,
         )
 
-        async with aiofiles.open(path, "wb") as f:
-            async for chunk in response.content.iter_chunked(1024 * 1024):
-                await f.write(chunk)
-                self.ui.progbar_video.update(task_id, advance=len(chunk))
-
-        self.ui.progbar_video.remove_task(task_id)
+        try:
+            async with aiofiles.open(path, "ab" if resume_point > 0 else "wb") as f:
+                async for chunk in response.content.iter_chunked(1024 * 1024):
+                    await f.write(chunk)
+                    self.ui.progbar_video.update(task_id, advance=len(chunk))
+        except asyncio.TimeoutError:
+            raise ParserError(
+                f"Timeout podczas pobierania '{desc}'. "
+            )
+        finally:
+            self.ui.progbar_video.remove_task(task_id)
 
     async def merge_dash_streams(
         self, video_path: Path, audio_path: Path, output_path: Path
@@ -191,8 +213,6 @@ class Video:
         audio_tmp = self.get_dash_audio_filepath()
 
         self.filepath.unlink(missing_ok=True)
-        video_tmp.unlink(missing_ok=True)
-        audio_tmp.unlink(missing_ok=True)
 
         try:
             await self.download_url_to_file(
@@ -207,8 +227,9 @@ class Video:
             )
             await self.merge_dash_streams(video_tmp, audio_tmp, self.filepath)
         finally:
-            video_tmp.unlink(missing_ok=True)
-            audio_tmp.unlink(missing_ok=True)
+            if self.filepath.exists():
+                video_tmp.unlink(missing_ok=True)
+                audio_tmp.unlink(missing_ok=True)
 
         download_state.completed += 1
 
@@ -449,6 +470,7 @@ class Video:
         block_size = 1024
         desc = f"{self.title}.mp4 [{self.resolution}]"
         self.filepath.unlink(missing_ok=True)
+
         assert self.ui.progbar_video
         task_id = self.ui.progbar_video.add_task(
             "download",
@@ -456,12 +478,20 @@ class Video:
             total=self.resume_point + self.remaining_size,
             completed=self.resume_point,
         )
-        async with aiofiles.open(self.partial_filepath, "ab") as f:
-            async for chunk in self.video_stream.content.iter_chunked(
-                block_size * block_size
-            ):
-                await f.write(chunk)
-                self.ui.progbar_video.update(task_id, advance=len(chunk))
+
+        try:
+            async with aiofiles.open(self.partial_filepath, "ab") as f:
+                async for chunk in self.video_stream.content.iter_chunked(
+                    block_size * block_size
+                ):
+                    await f.write(chunk)
+                    self.ui.progbar_video.update(task_id, advance=len(chunk))
+        except asyncio.TimeoutError:
+            raise ParserError(
+                f"Timeout podczas pobierania '{desc}'. "
+            )
+        finally:
+            self.ui.progbar_video.remove_task(task_id)
+
         self.partial_filepath.rename(self.filepath)
-        self.ui.progbar_video.remove_task(task_id)
         download_state.completed += 1


### PR DESCRIPTION
Fixes #14

Summary:

* detect MPD manifest responses instead of treating them as direct MP4 files
* parse the MPD file and select the requested video representation
* download separate video and audio streams
* merge them into a final MP4 using ffmpeg
* validate `videoGetLink` responses before using them as URLs

Tested with:

* videos returning direct downloadable URLs
* older videos returning `.mpd` manifests instead of direct files
* cases where `videoGetLink` returns a non-URL response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MPEG‑DASH support with automatic video/audio selection and automatic merging into final files.

* **Bug Fixes**
  * Improved network resilience: stricter link validation, timeouts, and better error capture/logging for download attempts.
  * Handled age-restricted content flow and improved title detection fallbacks.

* **Chores**
  * Added an error list to download state and surface detailed error summaries after runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->